### PR TITLE
Fix: HobbyPage API Error 수정

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -61,6 +61,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       suspense: true,
+      refetchOnWindowFocus: false,
     },
   },
 });

--- a/src/pages/hobby/constants/index.ts
+++ b/src/pages/hobby/constants/index.ts
@@ -1,0 +1,1 @@
+export const LIST_SIZE = 8;

--- a/src/pages/hobby/hooks/useFetchHobbies.ts
+++ b/src/pages/hobby/hooks/useFetchHobbies.ts
@@ -1,12 +1,15 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { LIST_SIZE } from '../constants';
 
-const fetchHobbies = async () =>
-  await (await fetch(`/api/v1/hobbies/sub`)).json();
+const fetchHobbies = async (pageParam: string) =>
+  await (
+    await fetch(`/api/v1/hobbies/sub?page=${pageParam}&size=${LIST_SIZE}`)
+  ).json();
 
 const useFetchHobbies = () =>
   useInfiniteQuery({
     queryKey: ['hobbies'],
-    queryFn: fetchHobbies,
+    queryFn: ({ pageParam = 1 }) => fetchHobbies(pageParam),
     getNextPageParam: (_, allPages) => allPages.length + 1,
   });
 

--- a/src/pages/hobby/index.tsx
+++ b/src/pages/hobby/index.tsx
@@ -44,7 +44,7 @@ const Hobby = () => {
           {hobbies.map((data) => (
             <CardContainer
               onClick={() => {
-                navigate('/question/step3/1');
+                navigate(`/question/step3/${data.id}`);
               }}
             >
               <CardMedia src={demo} alt={data.name} />
@@ -52,7 +52,7 @@ const Hobby = () => {
               <Ripple duration={700} color="#ffffff" />
             </CardContainer>
           ))}
-          <div ref={ref}>test</div>
+          <div ref={ref} />
         </List>
       </ContentContainer>
     </Container>
@@ -112,6 +112,8 @@ const CardContent = styled.div<{ text: string }>`
   color: ${colors.white};
   font-size: ${(props) => (props.text.length % 3 === 1 ? 20 : 25)}px;
   font-weight: 900;
+  font-size: 1.2rem;
+  white-space: nowrap;
   text-align: center;
 `;
 


### PR DESCRIPTION
## 작업내용
- `useFetchHobbies.ts` 모듈 내 `fetchHobbie` fetch 함수 쿼리스트링 추가
```ts
//pages/hobby/hooks/useFetchHobbies.ts
const fetchHobbies = async (pageParam: string) =>
  await (
    await fetch(`/api/v1/hobbies/sub?page=${pageParam}&size=${LIST_SIZE}`)  <= pageParam 파라미터 추가 및 전달
  ).json();
```
-    무한스크롤 사이즈 상수로 관리
```ts
// pages/hobby/constants/index.ts
export const LIST_SIZE = 8;
```
- `useFetchHobbies.ts` 모듈 내 `useInfiniteQuery`  queryFn 파라미터 추가
```ts
// pages/hobby/hooks/useFetchHobbies.ts
const useFetchHobbies = () =>
  useInfiniteQuery({
    queryKey: ['hobbies'],
    queryFn: ({ pageParam = 1 }) => fetchHobbies(pageParam),  // <= pageParam 파라미터 추가 및 전달
    getNextPageParam: (_, allPages) => allPages.length + 1,
  });
```

## 스크린샷

![cap](https://github.com/jamanchi/jamanchi-front/assets/17325845/61d4cdca-ceb2-4c3f-bb6e-dc82e2557a55)





