### PR TITLE
Fix: 배포환경 refresh 시 notFound Error 조치

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,8 @@ from = "/proxy/*"
   to = "https://port-0-jamanchi-back-7xwyjq992llj9hm2l9.sel4.cloudtype.app/:splat"  
   status = 200
   force = true
+
+[[redirects]]
+from = "/*"
+  to = "/index"  
+  status = 200


### PR DESCRIPTION
## 작업내용
- netlify.toml redirects 경로 추가
```
[[redirects]]
from = "/proxy/*"
  to = "https://port-0-jamanchi-back-7xwyjq992llj9hm2l9.sel4.cloudtype.app/:splat"  
  status = 200
  force = true

[[redirects]] // 추가
from = "/*"
  to = "/index"  
  status = 200 
```
close #33 